### PR TITLE
Add parallels desktop vagrant provider stanza.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,14 @@
 Vagrant.configure('2') do |config|
   config.vm.box = 'ubuntu-20.04-amd64'
 
+  config.vm.provider :parallels do |lv, config|
+    config.vm.box = 'generic/ubuntu2004'
+    lv.memory = 4*1024
+    lv.cpus = 4
+    lv.customize ["set", :id, "--nested-virt", "on"]
+    config.vm.synced_folder '.', '/vagrant'
+  end
+
   config.vm.provider :libvirt do |lv, config|
     lv.memory = 4*1024
     lv.cpus = 4


### PR DESCRIPTION
Might help someone who finds themselves on a Mac without a working virtualbox or vmware provider for vagrant.

** Note that you require parallels desktop [Pro or Business edition for the vagrant plugin to work](https://parallels.github.io/vagrant-parallels/) **

